### PR TITLE
Load Plugin CSS in head to fix flash while loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
 		<!-- light editor<link rel="stylesheet" href="lib/css/light.css">-->
 		<!-- dark editor--><link rel="stylesheet" href="lib/css/dark.css">
 		<link rel="stylesheet" href="lib/css/zenburn.css">
+		
+		<link rel="stylesheet" href="plugin/accessibility-helper/css/accessibility-helper.css">
 
 		<!-- If the query includes 'print-pdf', include the PDF print sheet -->
 		<script>

--- a/plugin/accessibility-helper/js/accessibility-helper.js
+++ b/plugin/accessibility-helper/js/accessibility-helper.js
@@ -14,20 +14,6 @@
  * Copyright (C) 2015 Marcy Sutton, http://marcysutton.com
  */
 
-var loadA11yPluginCSS = (function(){
-	var cssId = 'a11yPluginCSS';
-	if (!document.getElementById(cssId)) {
-	    var head  = document.getElementsByTagName('head')[0];
-	    var link  = document.createElement('link');
-	    link.id   = cssId;
-	    link.rel  = 'stylesheet';
-	    link.type = 'text/css';
-	    link.href = 'plugin/accessibility-helper/css/accessibility-helper.css';
-	    link.media = 'all';
-	    head.appendChild(link);
-	}
-});
-
 var PLUGIN_SLIDES = [];
 
 var SlideAccessibility = (function(){
@@ -35,8 +21,6 @@ var SlideAccessibility = (function(){
 	'use strict';
 
   var SLIDE_SELECTOR = '.slides > section';
-
-	loadA11yPluginCSS();
 
   // get slides, wrap contents in 'accessibilityWrapper'
 	// only wrap sections containing content


### PR DESCRIPTION
I noticed while updating the Git and Github slides that the accessibility plugin's skip links flash as they are generated and their stylesheet is still loading. By loading the CSS in the HTML `<head>`, the styles are picked up sooner and the flash can be avoided.
